### PR TITLE
Implement basic check functionality.

### DIFF
--- a/clrtrust
+++ b/clrtrust
@@ -63,8 +63,7 @@ EERR=255        # general error
 # in form of:
 # <file name>\t<sha-256 fingerprint>
 find_certs() {
-    local dir
-    dir=$1
+    local dir=$1
     if [ -z $dir ]; then return 255; fi
     if [ ! -d $dir ]; then return 255; fi
     find $dir -maxdepth 1 -type f | while read f; do
@@ -84,6 +83,10 @@ find_all_certs() {
     find_certs $CLR_LOCAL_TRUST_SRC/trusted
 }
 
+print_verbose_error() {
+    test -n "$VERBOSE" && 1>&2 printf "%s" "$@" && 1>&2 echo
+}
+
 print_check_help() {
     cat <<EOF
 Usage: ${BASENAME} check [-h|--help] [-v|--verbose]
@@ -96,56 +99,45 @@ EOF
 }
 
 cmd_check() {
-    local opt_verbose
-    local ret # return value
-
-    ret=0
 
     while [ $# -gt 0 ]; do
         case $1 in
-            -h|--help)
+            ("-h"|"--help")
                 print_check_help
                 return 0
                 ;;
-            -v|--verbose)
-                opt_verbose=1
+            ("-v"|"--verbose")
+                VERBOSE=1
                 shift
                 ;;
-            *)
+            (*)
                 print_check_help
                 return $EINVAL
                 ;;
         esac
     done
 
-    if [ ! -z "${VERBOSE}" ]; then
-        opt_verbose=1
-    fi
-
     if [ -e "${CLR_LOCAL_TRUST_SRC}" ]; then
         if [ ! -d "${CLR_LOCAL_TRUST_SRC}" ]; then
             1>&2 echo "${CLR_LOCAL_TRUST_SRC} must be a directory."
-            test ! -z $opt_verbose && 1>&2 cat <<EOF
-    ${CLR_LOCAL_TRUST_SRC} is used by ${BASENAME} to store local (user-added) trust and
-    distrust data.
-EOF
-            ret=$EBADST
+            print_verbose_error                                                 \
+"${CLR_LOCAL_TRUST_SRC} is used by ${BASENAME} to store local (user-added)"      \
+" trust and distrust data."
+            return $EBADST
         fi
-        if [ -e "${CLR_LOCAL_TRUST_SRC}/distrusted" -a ! -d "${CLR_LOCAL_TRUST_SRC}/distrusted" ]; then
+        if [ -e "${CLR_LOCAL_TRUST_SRC}/distrusted" ] && [ ! -d "${CLR_LOCAL_TRUST_SRC}/distrusted" ]; then
             1>&2 echo "$CLR_LOCAL_TRUST_SRC/distrusted must be a directory."
-            test ! -z $opt_verbose && 1>&2 cat <<EOF
-    ${CLR_LOCAL_TRUST_SRC}/trusted is a directory used by ${BASENAME} to store
-    trusted root CA certificates.
-EOF
-            ret=$EBADST
+            print_verbose_error                                                 \
+"${CLR_LOCAL_TRUST_SRC}/trusted is a directory used by ${BASENAME} to store"     \
+" trusted root CA certificates."
+            return $EBADST
         fi
-        if [ -e "${CLR_LOCAL_TRUST_SRC}/trusted" -a ! -d "${CLR_LOCAL_TRUST_SRC}/trusted" ]; then
+        if [ -e "${CLR_LOCAL_TRUST_SRC}/trusted" ] && [ ! -d "${CLR_LOCAL_TRUST_SRC}/trusted" ]; then
             1>&2 echo "$CLR_LOCAL_TRUST_SRC/trusted must be a directory."
-            test ! -z $opt_verbose && 1>&2 cat <<EOF
-    ${CLR_LOCAL_TRUST_SRC}/distrusted is a directory used by ${BASENAME} to store
-    distrusted root CA certificates.
-EOF
-            ret=$EBADST
+            print_verbose_error                                                 \
+"${CLR_LOCAL_TRUST_SRC}/distrusted is a directory used by ${BASENAME} to store"  \
+"distrusted root CA certificates."
+            return $EBADST
         fi
     fi # it's OK if CLR_LOCAL_TRUST_SRC does not exist
 
@@ -153,22 +145,20 @@ EOF
         for dir in "${CLR_CLEAR_TRUST_SRC}" "${CLR_CLEAR_TRUST_SRC}/trusted"; do
             if [ ! -d "${dir}" ]; then
                 1>&2 echo "${dir} must be a directory."
-                test ! -z $opt_verbose && 1>&2 cat <<EOF
-    ${dir} is a directory which contains trust and distrust data provided by
-    Clear Linux. It is installed initially and updated by swupd. Remove ${dir}
-    and run 'swupd verify --fix' to reinstall.
-EOF
-                ret=$EBADST
+                print_verbose_error                                             \
+"${dir} is a directory which contains trust and distrust data provided by"       \
+" Clear: Linux. It is installed initially and updated by swupd. Remove ${dir}"    \
+" and run 'swupd verify --fix' to reinstall."
+                return $EBADST
             fi
         done
     else # it's not OK if CLR_CLEAR_TRUST_SRC does not exist
         1>&2 echo "${CLR_CLEAR_TRUST_SRC} does not exist."
-        test ! -z $opt_verbose && 1>&2 cat <<EOF
-    ${CLR_CLEAR_TRUST_SRC} is a directory which contains trust and distrust data
-    provided by Clear Linux. It is installed initially and updated by swupd. Run
-    'swupd verify --fix' to reinstall.
-EOF
-        ret=$EBADST
+        print_verbose_error                                                     \
+"${CLR_CLEAR_TRUST_SRC} is a directory which contains trust and distrust data"   \
+" provided by Clear Linux. It is installed initially and updated by swupd. Run"   \
+" 'swupd verify --fix' to reinstall."
+        return $EBADST
     fi
 
     dir=$(dirname ${CLR_TRUST_STORE})
@@ -176,22 +166,21 @@ EOF
         1>&2 echo "${dir} does not exit."
     fi
 
-    if [ "x${CLR_TRUST_STORE}" = "x${CLR_TRUST_STORE_DFLT}" ]; then
+    if [ "${CLR_TRUST_STORE}" = "${CLR_TRUST_STORE_DFLT}" ]; then
         usr="root"
     else
         usr=${USER}
     fi
 
     stat=($(stat -L -c "0%a %G %U" "$dir"))
+    if [ $? -ne 0 ]; then
+        return $EERR
+    fi
     ownusr=${stat[2]}
     owngrp=${stat[1]}
     perm=${stat[0]}
 
-    if [ -z "$perm" -o -z "$ownusr" -o -z "$owngrp" -o -z "$usr" ]; then
-        return $EERR
-    fi
-
-    if [ "x$ownusr" = "x$usr" ] && (( $perm & 0200 )); then
+    if [ "$ownusr" = "$usr" ] && (( $perm & 0200 )); then
         true
     elif (( $perm & 0002 )); then
         true
@@ -205,20 +194,18 @@ EOF
         done
         if [ $found -ne 1 ]; then
             1>&2 echo "${dir} is not writeable for ${usr}."
-            test ! -z ${opt_verbose} && 1>&2 echo <<EOF
-    ${dir} must be writeable: the store will be generated at ${CLR_TRUST_STORE}
-EOF
-            ret=$EPERM
+            print_verbose_error         \
+"${dir} must be writeable: the store will be generated at ${CLR_TRUST_STORE}"
+            return $EPERM
         fi
     else
         1>&2 echo "${dir} is not writeable for ${usr}."
-        test ! -z ${opt_verbose} && 1>&2 echo <<EOF
-    ${dir} must be writeable: the store will be generated at ${CLR_TRUST_STORE}
-EOF
-        ret=$EPERM
+        print_verbose_error             \
+"${dir} must be writeable: the store will be generated at ${CLR_TRUST_STORE}"
+        return $EPERM
     fi
 
-    return $ret
+    return 0
 }
 
 ensure_local_trust_src() {
@@ -256,22 +243,22 @@ cmd_generate() {
 
     while [ $# -gt 0 ]; do
         case $1 in
-            -h|--help)
+            ("-h"|"--help")
                 print_generate_help
                 return 0
                 ;;
-            -s) # internal option
+            ("-s") # internal option
                 opt_skip_check=1
                 shift
                 ;;
-            *)
+            (*)
                 print_generate_help
                 return $EINVAL
                 ;;
         esac
     done
 
-    if [ ! -z "$opt_skip_check" ]; then
+    if [ -n "$opt_skip_check" ]; then
         # run check
         cmd_check
         ret=$?
@@ -285,7 +272,7 @@ cmd_generate() {
 
     # handle the duplicates
     dup_certs=$(echo "${ca_certs}" | cut -f 2 | sort | uniq -d)
-    if [ ! -z "$dup_certs" ]; then
+    if [ -n "$dup_certs" ]; then
         dup_certs_cnt=$(echo "$dup_certs" | wc -l)
         echo "$dup_certs_cnt certificate(s) are duplicated. Cleaning up..."
         for h in ${dup_certs}; do
@@ -299,7 +286,7 @@ $tmp"
     # remove the distrusted ones
     distrust_certs=$(find_certs $CLR_LOCAL_TRUST_SRC/distrusted)
     ca_certs_cnt=$(echo "$ca_certs" | wc -l)
-    if [ ! -z "$distrust_certs" ]; then
+    if [ -n "$distrust_certs" ]; then
         distrust_certs_cnt=$(echo "$distrust_certs" | wc -l)
         echo "Distrusting $distrust_certs_cnt certificate(s)."
         for h in $(echo "$distrust_certs" | cut -f 2); do
@@ -315,7 +302,7 @@ $tmp"
     mkdir -p $CLR_STORE_STAGE/anchors
     mkdir -p $CLR_STORE_STAGE/compat
 
-    if [ ! -z "${ca_certs}" ]; then
+    if [ -n "${ca_certs}" ]; then
         echo "${ca_certs}" | cut -f 1 | xargs -d '\n' cp -t $CLR_STORE_STAGE/anchors
     fi
 
@@ -373,19 +360,20 @@ cmd_add() {
     local err
     local err_content
     local tmp
-    local opt_force
-    opt_force=0
+    local opt_force=0
+
     while [ $# -gt 0 ]; do
         case $1 in
-            -h|--help)
+            ("-h"|"--help")
                 print_add_help
                 return 0
                 ;;
-            -f|--force)
+            ("-f"|"--force")
                 opt_force=1
                 shift
                 ;;
-            *)
+            (*)
+                echo "$1"
                 # first empty line will be deleted few lines later
                 files="$files
 $1"
@@ -428,7 +416,7 @@ $1"
         fi
         finger=${finger#SHA1 Fingerprint=}
         is_root_ca "$f"
-        if [ $opt_force -ne 1 -a $? -ne 0 ]; then
+        if [ $? -ne 0 ] && [ $opt_force -ne 1 ]; then
             cat <<EOF
 Certificate $f is not a Root CA. Use --force and proper judgement to enforce.
 EOF
@@ -502,13 +490,14 @@ cmd_list() {
     local info
     local indent
     local err
+
     while [ $# -gt 0 ]; do
         case $1 in
-            -h|--help)
+            ("-h"|"--help")
                 print_list_help
                 return 0
                 ;;
-            *)
+            (*)
                 print_list_help
                 return $EINVAL
                 ;;
@@ -524,7 +513,7 @@ cmd_list() {
     fi
     certs=$(find ${CLR_TRUST_STORE}/anchors -maxdepth 1 -type f | LC_COLLATE=C sort)
     if [ -z "${certs}" ]; then
-        test ! -z $VERBOSE && echo "Nothing is trusted. No anchors found in ${CLR_TRUST_STORE}."
+        print_verbose_error "Nothing is trusted. No anchors found in ${CLR_TRUST_STORE}."
         return 0
     fi
 
@@ -571,16 +560,16 @@ cmd_remove() {
 
     while [ $# -gt 0 ]; do
         case $1 in
-            -h|--help)
+            ("-h"|"--help")
                 print_remove_help
                 return 0
                 ;;
-            -f|--force)
+            ("-f"|"--force")
                 # TODO: implement forcing
                 opt_force=1
                 true
                 ;;
-            *)
+            (*)
                 if [ -f "$1" ]; then
                     # need newline as a separator in case filename comes with
                     # spaces. first empty line will be deleted later.
@@ -605,7 +594,7 @@ $1"
     err=$(mktemp)
     out=$(mktemp)
     files=$(echo "$files" | sed -e '1d')
-    test ! -z "$files" && echo "$files" | while read f; do
+    test -n "$files" && echo "$files" | while read f; do
         finger=$(openssl x509 -in "${f}" -noout -fingerprint -sha1 2>/dev/null)
         if [ $? -ne 0 ]; then
             1>&2 echo "${f} is not an X.509 certificate." >>$err
@@ -615,9 +604,9 @@ $1"
         printf "%s\t%s\n" "${f}" "${finger}"
     done >$out
     invld_files=$(cat $err)
-    if [ ! -z "$invld_files" ]; then
-        2>&1 echo "$invld_files"
-        2>&1 echo "Trust store has not been modified."
+    if [ -n "$invld_files" ]; then
+        2>&1 echo "$invld_files
+Trust store has not been modified."
         rm $out $err
         return $EERR
     fi
@@ -638,7 +627,7 @@ $1"
         fi
     done >$out
     files=$(cat $out)
-    if [ ! -z "$files" ]; then
+    if [ -n "$files" ]; then
         echo "$files" | while read f; do
             if [ ! -e $CLR_LOCAL_TRUST_SRC/distrusted ]; then
                 mkdir $CLR_LOCAL_TRUST_SRC/distrusted
@@ -676,7 +665,6 @@ EOF
 }
 
 ##### GLOBAL VARS/OPTIONS
-VERBOSE=
 COMMAND=""
 BASENAME=$(basename $0) # this may not work, but we don't care too much
 ARGS=$*
@@ -690,29 +678,30 @@ if ! has_p11kit; then
 fi
 
 while [ $# -gt 0 ]; do
-    opt=$1
-    case $opt in
-        -v|--verbose)
+    case $1 in
+        ("-v"|"--verbose")
             VERBOSE=1
+            shift
+            continue
             ;;
-        -h|--help)
+        ("-h"|"--help")
             print_help
             exit 0
             ;;
-        generate|list|add|remove|restore|check)
-            COMMAND=$opt
+        ("generate"|"list"|"add"|"remove"|"restore"|"check")
+            COMMAND=$1
+            shift
             ;;
     esac
-    shift
-    if [ ! -z $COMMAND ]; then
+    if [ -n "$COMMAND" ]; then
         break
     fi
 done
 
 case $COMMAND in
-    generate|add|remove|restore)
+    ("generate"|"add"|"remove"|"restore")
         # must be root if writing to the default location
-        if [ "x$CLR_TRUST_STORE" = "x$CLR_TRUST_STORE_DFLT" ]; then
+        if [ "$CLR_TRUST_STORE" = "$CLR_TRUST_STORE_DFLT" ]; then
             is_root
             if [ $? -ne 0 ]; then
                 exit $EPERM
@@ -722,32 +711,32 @@ case $COMMAND in
 esac
 
 case $COMMAND in
-    generate)
-        cmd_generate $*
+    ("generate")
+        cmd_generate "$@"
         exit $?
         ;;
-    add)
+    ("add")
         cmd_add "$@"
         exit $?
         ;;
-    list)
-        cmd_list $*
+    ("list")
+        cmd_list "$@"
         exit $?
         ;;
-    remove)
+    ("remove")
         cmd_remove "$@"
         exit $?
         ;;
-    check)
-        cmd_check $*
+    ("check")
+        cmd_check "$@"
         exit $?
         ;;
-    restore)
+    ("restore")
         1>&2 echo "$COMMAND not yet supported."
         exit $EINVAL
         ;;
-    *)
-        if [ ! -z $COMMAND ]; then
+    (*)
+        if [ -n $COMMAND ]; then
             1>&2 echo "Command not understood: $COMMAND"
         fi
         print_help

--- a/clrtrust
+++ b/clrtrust
@@ -84,6 +84,143 @@ find_all_certs() {
     find_certs $CLR_LOCAL_TRUST_SRC/trusted
 }
 
+print_check_help() {
+    cat <<EOF
+Usage: ${BASENAME} check [-h|--help] [-v|--verbose]
+
+    Checks the environment and reports issues found.
+
+    -h | --help         Prints this help message and exits
+    -v | --verbose      Provides extra explanations for the errors encountered
+EOF
+}
+
+cmd_check() {
+    local opt_verbose
+    local ret # return value
+
+    ret=0
+
+    while [ $# -gt 0 ]; do
+        case $1 in
+            -h|--help)
+                print_check_help
+                return 0
+                ;;
+            -v|--verbose)
+                opt_verbose=1
+                shift
+                ;;
+            *)
+                print_check_help
+                return $EINVAL
+                ;;
+        esac
+    done
+
+    if [ ! -z "${VERBOSE}" ]; then
+        opt_verbose=1
+    fi
+
+    if [ -e "${CLR_LOCAL_TRUST_SRC}" ]; then
+        if [ ! -d "${CLR_LOCAL_TRUST_SRC}" ]; then
+            1>&2 echo "${CLR_LOCAL_TRUST_SRC} must be a directory."
+            test ! -z $opt_verbose && 1>&2 cat <<EOF
+    ${CLR_LOCAL_TRUST_SRC} is used by ${BASENAME} to store local (user-added) trust and
+    distrust data.
+EOF
+            ret=$EBADST
+        fi
+        if [ -e "${CLR_LOCAL_TRUST_SRC}/distrusted" -a ! -d "${CLR_LOCAL_TRUST_SRC}/distrusted" ]; then
+            1>&2 echo "$CLR_LOCAL_TRUST_SRC/distrusted must be a directory."
+            test ! -z $opt_verbose && 1>&2 cat <<EOF
+    ${CLR_LOCAL_TRUST_SRC}/trusted is a directory used by ${BASENAME} to store
+    trusted root CA certificates.
+EOF
+            ret=$EBADST
+        fi
+        if [ -e "${CLR_LOCAL_TRUST_SRC}/trusted" -a ! -d "${CLR_LOCAL_TRUST_SRC}/trusted" ]; then
+            1>&2 echo "$CLR_LOCAL_TRUST_SRC/trusted must be a directory."
+            test ! -z $opt_verbose && 1>&2 cat <<EOF
+    ${CLR_LOCAL_TRUST_SRC}/distrusted is a directory used by ${BASENAME} to store
+    distrusted root CA certificates.
+EOF
+            ret=$EBADST
+        fi
+    fi # it's OK if CLR_LOCAL_TRUST_SRC does not exist
+
+    if [ -e "${CLR_CLEAR_TRUST_SRC}" ]; then
+        for dir in "${CLR_CLEAR_TRUST_SRC}" "${CLR_CLEAR_TRUST_SRC}/trusted"; do
+            if [ ! -d "${dir}" ]; then
+                1>&2 echo "${dir} must be a directory."
+                test ! -z $opt_verbose && 1>&2 cat <<EOF
+    ${dir} is a directory which contains trust and distrust data provided by
+    Clear Linux. It is installed initially and updated by swupd. Remove ${dir}
+    and run 'swupd verify --fix' to reinstall.
+EOF
+                ret=$EBADST
+            fi
+        done
+    else # it's not OK if CLR_CLEAR_TRUST_SRC does not exist
+        1>&2 echo "${CLR_CLEAR_TRUST_SRC} does not exist."
+        test ! -z $opt_verbose && 1>&2 cat <<EOF
+    ${CLR_CLEAR_TRUST_SRC} is a directory which contains trust and distrust data
+    provided by Clear Linux. It is installed initially and updated by swupd. Run
+    'swupd verify --fix' to reinstall.
+EOF
+        ret=$EBADST
+    fi
+
+    dir=$(dirname ${CLR_TRUST_STORE})
+    if [ ! -e "$dir" ]; then
+        1>&2 echo "${dir} does not exit."
+    fi
+
+    if [ "x${CLR_TRUST_STORE}" = "x${CLR_TRUST_STORE_DFLT}" ]; then
+        usr="root"
+    else
+        usr=${USER}
+    fi
+
+    stat=($(stat -L -c "0%a %G %U" "$dir"))
+    ownusr=${stat[2]}
+    owngrp=${stat[1]}
+    perm=${stat[0]}
+
+    if [ -z "$perm" -o -z "$ownusr" -o -z "$owngrp" -o -z "$usr" ]; then
+        return $EERR
+    fi
+
+    if [ "x$ownusr" = "x$usr" ] && (( $perm & 0200 )); then
+        true
+    elif (( $perm & 0002 )); then
+        true
+    elif (( $perm & 0020 )); then
+        grps=$(groups $usr)
+        found=0
+        for g in $grps; do
+            if [ $g = $owngrp ]; then
+                found=1
+            fi
+        done
+        if [ $found -ne 1 ]; then
+            1>&2 echo "${dir} is not writeable for ${usr}."
+            test ! -z ${opt_verbose} && 1>&2 echo <<EOF
+    ${dir} must be writeable: the store will be generated at ${CLR_TRUST_STORE}
+EOF
+            ret=$EPERM
+        fi
+    else
+        1>&2 echo "${dir} is not writeable for ${usr}."
+        test ! -z ${opt_verbose} && 1>&2 echo <<EOF
+    ${dir} must be writeable: the store will be generated at ${CLR_TRUST_STORE}
+EOF
+        ret=$EPERM
+    fi
+
+    return $ret
+}
+
 ensure_local_trust_src() {
     mkdir -p ${CLR_LOCAL_TRUST_SRC}/trusted     \
              ${CLR_LOCAL_TRUST_SRC}/distrusted   \
@@ -113,19 +250,36 @@ cmd_generate() {
     local dup_certs_cnt
     local distrust_certs_cnt
     local tmp
+    local ret
+    local opt_skip_check # this option is used when called internally after the
+                         # a check has been performed
 
-    case "$#:$1" in
-        0:)
-            ;;
-        -h|--help)
-            print_generate_help
-            return 0
-            ;;
-        *)
-            print_generate_help
-            return $EINVAL
-            ;;
-    esac
+    while [ $# -gt 0 ]; do
+        case $1 in
+            -h|--help)
+                print_generate_help
+                return 0
+                ;;
+            -s) # internal option
+                opt_skip_check=1
+                shift
+                ;;
+            *)
+                print_generate_help
+                return $EINVAL
+                ;;
+        esac
+    done
+
+    if [ ! -z "$opt_skip_check" ]; then
+        # run check
+        cmd_check
+        ret=$?
+        if [ $ret -ne 0 ]; then
+            return $ret
+        fi
+    fi
+
     # find all the certificates
     ca_certs=$(find_all_certs)
 
@@ -239,6 +393,14 @@ $1"
                 ;;
         esac
     done
+
+    # run check
+    cmd_check
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        return $ret
+    fi
+
     if [ -z "$files" ]; then
         1>&2 echo "Specify certificate(s) to add."
         print_add_help
@@ -312,7 +474,7 @@ EOF
                 rm "${l}"
             fi
         done
-        cmd_generate
+        cmd_generate -s
     else
         ret=$EERR
         1>&2 echo "$out_content"
@@ -382,21 +544,6 @@ cmd_list() {
     return 0
 }
 
-print_check_help() {
-    true
-}
-
-cmd_check() {
-    if [ -e $CLR_LOCAL_TRUST_SRC/distrusted ]; then
-        if [ ! -d $CLR_LOCAL_TRUST_SRC/distrusted ]; then
-            1>&2 echo "$CLR_LOCAL_TRUST_SRC/distrusted must be a directory"
-            return $EBADST
-        fi
-    fi
-
-    return 0
-}
-
 print_remove_help() {
     cat <<EOF
 Usage: ${BASENAME} remove [-f|--force] <filename|id>...
@@ -420,6 +567,8 @@ cmd_remove() {
     local invld_files
     local certs
     local opt_force
+    local ret
+
     while [ $# -gt 0 ]; do
         case $1 in
             -h|--help)
@@ -445,10 +594,13 @@ $1"
         shift
     done
 
+    # run check
     cmd_check
-    if [ $? -eq $EBADST ]; then
-        return $EBADST
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        return $ret
     fi
+
     ensure_local_trust_src
     err=$(mktemp)
     out=$(mktemp)
@@ -499,7 +651,7 @@ $1"
                 rm "$f"
             fi
         done
-        cmd_generate
+        cmd_generate -s
     else
         echo "Nothing to do."
     fi
@@ -586,7 +738,11 @@ case $COMMAND in
         cmd_remove "$@"
         exit $?
         ;;
-    restore|check)
+    check)
+        cmd_check $*
+        exit $?
+        ;;
+    restore)
         1>&2 echo "$COMMAND not yet supported."
         exit $EINVAL
         ;;

--- a/test/check-negative-no-clear-src.bats
+++ b/test/check-negative-no-clear-src.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# Copyright 2017 Intel Corporation
+
+load test_lib
+
+setup() {
+    find_clrtrust
+    setup_fs
+    rm -r $CLR_CLEAR_TRUST_SRC
+    cp $CERTS/c[3-4].pem $CLR_LOCAL_TRUST_SRC/trusted
+}
+
+@test "check fails when there's no Clear source" {
+    run $CLRTRUST check
+    [ $status -ne 0 ]
+    [ ! -z "$output" ]
+}
+
+teardown() {
+    remove_fs
+}
+
+# vim: ft=sh:sw=4:ts=4:et:tw=80:si:noai:nocin

--- a/test/check-negative-no-clear-src.bats
+++ b/test/check-negative-no-clear-src.bats
@@ -13,7 +13,7 @@ setup() {
 @test "check fails when there's no Clear source" {
     run $CLRTRUST check
     [ $status -ne 0 ]
-    [ ! -z "$output" ]
+    [ -n "$output" ]
 }
 
 teardown() {

--- a/test/check-negative-no-var.bats
+++ b/test/check-negative-no-var.bats
@@ -15,7 +15,7 @@ setup() {
 @test "check fails when there's no parent for trust store" {
     run $CLRTRUST check
     [ $status -ne 0 ]
-    [ ! -z "$output" ]
+    [ -n "$output" ]
 }
 
 teardown() {

--- a/test/check-negative-no-var.bats
+++ b/test/check-negative-no-var.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# Copyright 2017 Intel Corporation
+
+load test_lib
+
+setup() {
+    find_clrtrust
+    setup_fs
+    cp $CERTS/c[1-2].pem $CLR_CLEAR_TRUST_SRC/trusted
+    cp $CERTS/c[3-4].pem $CLR_LOCAL_TRUST_SRC/trusted
+    dir=$(dirname ${CLR_TRUST_STORE})
+    rm -r $dir
+}
+
+@test "check fails when there's no parent for trust store" {
+    run $CLRTRUST check
+    [ $status -ne 0 ]
+    [ ! -z "$output" ]
+}
+
+teardown() {
+    remove_fs
+}
+
+# vim: ft=sh:sw=4:ts=4:et:tw=80:si:noai:nocin

--- a/test/check-negative-var-ro.bats
+++ b/test/check-negative-var-ro.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# Copyright 2017 Intel Corporation
+
+load test_lib
+
+setup() {
+    find_clrtrust
+    setup_fs
+    cp $CERTS/c[1-2].pem $CLR_CLEAR_TRUST_SRC/trusted
+    cp $CERTS/c[3-4].pem $CLR_LOCAL_TRUST_SRC/trusted
+    chmod 400 $(dirname ${CLR_TRUST_STORE})
+}
+
+@test "check fails when trust store cannot be written" {
+    run $CLRTRUST check
+    [ $status -ne 0 ]
+    [ ! -z "$output" ]
+}
+
+teardown() {
+    chmod 755 $(dirname ${CLR_TRUST_STORE})
+    remove_fs
+}
+
+# vim: ft=sh:sw=4:ts=4:et:tw=80:si:noai:nocin

--- a/test/check-negative-var-ro.bats
+++ b/test/check-negative-var-ro.bats
@@ -14,7 +14,7 @@ setup() {
 @test "check fails when trust store cannot be written" {
     run $CLRTRUST check
     [ $status -ne 0 ]
-    [ ! -z "$output" ]
+    [ -n "$output" ]
 }
 
 teardown() {

--- a/test/check-positive.bats
+++ b/test/check-positive.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# Copyright 2017 Intel Corporation
+
+load test_lib
+
+setup() {
+    find_clrtrust
+    setup_fs
+    cp $CERTS/c[1-2].pem $CLR_CLEAR_TRUST_SRC/trusted
+    cp $CERTS/c[3-4].pem $CLR_LOCAL_TRUST_SRC/trusted
+}
+
+@test "check on a correct environment" {
+    $CLRTRUST check
+}
+
+@test "check when there's no local source" {
+    rm -r $CLR_LOCAL_TRUST_SRC
+    $CLRTRUST check
+}
+
+teardown() {
+    remove_fs
+}
+
+# vim: ft=sh:sw=4:ts=4:et:tw=80:si:noai:nocin

--- a/test/test_lib.bash
+++ b/test/test_lib.bash
@@ -9,25 +9,23 @@ function find_clrtrust {
 }
 
 function setup_fs {
-    SOURCES=$(mktemp -d)
-    STORE=$(mktemp -d)
+    ROOT=$(mktemp -d)
     CERTS=$BATS_TEST_DIRNAME/certs
-    mkdir -p $SOURCES/etc/ca-certs/trusted
-    mkdir -p $SOURCES/etc/ca-certs/distrusted
-    mkdir -p $SOURCES/usr/share/ca-certs/trusted
-    mkdir -p $SOURCES/usr/share/ca-certs/distrusted
-    CLR_TRUST_STORE=$STORE
-    CLR_LOCAL_TRUST_SRC=$SOURCES/etc/ca-certs
-    CLR_CLEAR_TRUST_SRC=$SOURCES/usr/share/ca-certs
+    mkdir -p $ROOT/etc/ca-certs/trusted
+    mkdir -p $ROOT/etc/ca-certs/distrusted
+    mkdir -p $ROOT/usr/share/ca-certs/trusted
+    mkdir -p $ROOT/usr/share/ca-certs/distrusted
+    mkdir -p $ROOT/var/cache/ca-certs
+    CLR_TRUST_STORE=$ROOT/var/cache/ca-certs
+    STORE=$CLR_TRUST_STORE
+    CLR_LOCAL_TRUST_SRC=$ROOT/etc/ca-certs
+    CLR_CLEAR_TRUST_SRC=$ROOT/usr/share/ca-certs
     export CLR_TRUST_STORE CLR_LOCAL_TRUST_SRC CLR_CLEAR_TRUST_SRC
 }
 
 function remove_fs {
-    unset CLR_TRUST_STORE_DFLT
-    unset CLR_LOCAL_TRUST_SRC
-    unset CLR_CLEAR_TRUST_SRC
-    rm -rf $SOURCES
-    rm -rf $STORE
+    unset CLR_TRUST_STORE CLR_LOCAL_TRUST_SRC CLR_CLEAR_TRUST_SRC
+    rm -rf $ROOT
 }
 
 # vim: ft=sh:sw=4:ts=4:et:tw=80:ai


### PR DESCRIPTION
Implement check command that verifies that it has sufficient information and permissions to generate the trust store. It checks that:

* Local trust source `trusted` and `distrusted` are directories if they exist. 
* Clear trust source `trusted` does exist and is a directory
* Parent of the trust store directory exists and is writeable

`cmd_check` is also run from the command that manipulate the store.

There could be more interesting checks that could be implemented in the future, but this set provides basic guarantee that `check` will fail ahead of actually trying to generate anything.

Fixes #4 and #6.