### PR TITLE
Produce compatibility symlink for statically linked programs

### DIFF
--- a/clrtrust.in
+++ b/clrtrust.in
@@ -536,6 +536,10 @@ EOF
             $CLR_TRUST_STORE/compat/ca-roots.pem
     chmod 644 $CLR_TRUST_STORE/compat/ca-roots.pem
 
+    # Compatibility link for statically linked binaries
+    # This will yield /etc/ssl/certs/ca-certificates.crt path through tmpfiles
+    ln -s ../compat/ca-roots.pem $CLR_TRUST_STORE/anchors/ca-certificates.crt
+
     is_system_store && unlock
     trap - INT HUP TERM
 


### PR DESCRIPTION
This link, in combination with the /etc/ssl/certs symlink through tmpfiles,
will create the compatibility path /etc/ssl/certs/ca-certificates.crt.
This will help with statically linked (and hardcoded) programs such as
Go binaries or the Steam client.

Signed-off-by: Ikey Doherty <ikey.doherty@intel.com>